### PR TITLE
Add TypeScript parser with build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Incremental JSON Parser
+
+This repository provides an example implementation of a streaming JSON parser
+that can consume partial JSON data and yield immutable snapshots of the object
+as more data arrives.  It is useful when working with APIs that return JSON in a
+streaming manner, such as OpenAI's structured output.
+
+## Usage
+
+```typescript
+import { incrementalJsonParser } from './dist/incremental-json-parser.es.js';
+import { Readable } from 'stream';
+
+async function main() {
+  const data = '{"foo":1,"bar":[{"baz":2},3]}';
+  const chunks = [data.slice(0,5), data.slice(5,10), data.slice(10)];
+  const stream = Readable.from(chunks.map(c => Buffer.from(c)));
+  const reader = stream[Symbol.asyncIterator]();
+
+  for await (const obj of incrementalJsonParser({
+    async read() {
+      const r = await reader.next();
+      if (r.done) return { done: true };
+      return { done: false, value: r.value };
+    }
+  })) {
+    console.log(obj);
+  }
+}
+
+main();
+```
+
+## Development
+
+Install dependencies and run tests:
+
+```bash
+npm install
+npm test
+```
+
+Build the library:
+
+```bash
+npm run build
+```
+
+The parser reads from an object implementing the same interface as
+`ReadableStreamDefaultReader` and yields each time the root object is updated.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "incremental-json-parser",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^5.1.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/src/incrementalJsonParser.ts
+++ b/src/incrementalJsonParser.ts
@@ -1,0 +1,305 @@
+// Incremental JSON parser that yields partial objects as they are parsed.
+// The parser processes a reader compatible with `ReadableStreamDefaultReader`
+// and returns an async generator yielding immutable snapshots of the parsed
+// JSON structure.
+
+export interface IncrementalReader {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\n' || ch === '\r' || ch === '\t';
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= '0' && ch <= '9';
+}
+
+function isNumberChar(ch: string): boolean {
+  return (
+    isDigit(ch) ||
+    ch === '-' ||
+    ch === '+' ||
+    ch === 'e' ||
+    ch === 'E' ||
+    ch === '.'
+  );
+}
+
+type ContextType = 'object' | 'array';
+type ContextState =
+  | 'expectKeyOrEnd'
+  | 'expectKey'
+  | 'expectColon'
+  | 'expectValue'
+  | 'expectValueOrEnd'
+  | 'expectCommaOrEnd';
+
+class ParserContext {
+  type: ContextType;
+  value: any;
+  key: string | undefined;
+  state: ContextState;
+
+  constructor(type: ContextType, value: any) {
+    this.type = type;
+    this.value = value;
+    this.key = undefined;
+    this.state = type === 'object' ? 'expectKeyOrEnd' : 'expectValueOrEnd';
+  }
+}
+
+class IncrementalParser {
+  stack: ParserContext[] = [];
+  root: any = undefined;
+  buffer = '';
+  state: 'default' | 'string' | 'number' | 'literal' = 'default';
+  token = '';
+  escape = false;
+  updates: any[] = [];
+
+  feed(chunk: string): void {
+    this.buffer += chunk;
+    let i = 0;
+    while (i < this.buffer.length) {
+      const ch = this.buffer[i];
+      switch (this.state) {
+        case 'default':
+          if (isWhitespace(ch)) {
+            i++;
+            break;
+          }
+          if (ch === '{') {
+            const obj = {};
+            this._pushValue(obj);
+            this.stack.push(new ParserContext('object', obj));
+            i++;
+            break;
+          }
+          if (ch === '[') {
+            const arr = [];
+            this._pushValue(arr);
+            this.stack.push(new ParserContext('array', arr));
+            i++;
+            break;
+          }
+          if (ch === '}' || ch === ']') {
+            this._closeStructure(ch);
+            i++;
+            break;
+          }
+          if (ch === ',') {
+            this._comma();
+            i++;
+            break;
+          }
+          if (ch === ':') {
+            this._colon();
+            i++;
+            break;
+          }
+          if (ch === '"') {
+            this.state = 'string';
+            this.token = '';
+            i++;
+            break;
+          }
+          if (ch === '-' || isDigit(ch)) {
+            this.state = 'number';
+            this.token = ch;
+            i++;
+            break;
+          }
+          if (ch === 't' || ch === 'f' || ch === 'n') {
+            this.state = 'literal';
+            this.token = ch;
+            i++;
+            break;
+          }
+          throw new Error('Unexpected token ' + ch);
+        case 'string':
+          if (this.escape) {
+            this.token += ch;
+            this.escape = false;
+            i++;
+            break;
+          }
+          if (ch === '\\') {
+            this.escape = true;
+            i++;
+            break;
+          }
+          if (ch === '"') {
+            const value = JSON.parse('"' + this.token + '"');
+            this._pushValue(value);
+            this.state = 'default';
+            this.token = '';
+            i++;
+            break;
+          }
+          this.token += ch;
+          i++;
+          break;
+        case 'number':
+          if (isNumberChar(ch)) {
+            this.token += ch;
+            i++;
+            break;
+          }
+          this._pushValue(Number(this.token));
+          this.state = 'default';
+          this.token = '';
+          // retry this character in default state
+          continue;
+        case 'literal':
+          this.token += ch;
+          i++;
+          if (this.token === 'true') {
+            this._pushValue(true);
+            this.state = 'default';
+            this.token = '';
+            break;
+          }
+          if (this.token === 'false') {
+            this._pushValue(false);
+            this.state = 'default';
+            this.token = '';
+            break;
+          }
+          if (this.token === 'null') {
+            this._pushValue(null);
+            this.state = 'default';
+            this.token = '';
+            break;
+          }
+          if ('true'.startsWith(this.token) ||
+              'false'.startsWith(this.token) ||
+              'null'.startsWith(this.token)) {
+            break; // still pending
+          }
+          throw new Error('Unexpected token ' + this.token);
+      }
+    }
+    this.buffer = this.buffer.slice(i);
+  }
+
+  end(): any {
+    if (this.state === 'string' || this.state === 'number' || this.state === 'literal') {
+      throw new Error('Unexpected end of JSON input');
+    }
+    if (this.stack.length !== 0) {
+      throw new Error('Unexpected end of JSON input');
+    }
+    return this.root;
+  }
+
+  _pushValue(value: any): void {
+    if (this.stack.length === 0) {
+      this.root = value;
+      this.updates.push(this._cloneRoot());
+      return;
+    }
+    const ctx = this.stack[this.stack.length - 1];
+    if (ctx.type === 'array') {
+      if (ctx.state !== 'expectValue' && ctx.state !== 'expectValueOrEnd') {
+        throw new Error('Unexpected value in array');
+      }
+      ctx.value.push(value);
+      ctx.state = 'expectCommaOrEnd';
+    } else {
+      if (ctx.state === 'expectKey' || ctx.state === 'expectKeyOrEnd') {
+        ctx.key = value;
+        ctx.state = 'expectColon';
+        return;
+      }
+      if (ctx.state !== 'expectValue') {
+        throw new Error('Unexpected value in object');
+      }
+      ctx.value[ctx.key] = value;
+      ctx.key = undefined;
+      ctx.state = 'expectCommaOrEnd';
+    }
+    this.updates.push(this._cloneRoot());
+  }
+
+  _closeStructure(ch: string): void {
+    if (this.stack.length === 0) {
+      throw new Error('Unexpected closing bracket');
+    }
+    const ctx = this.stack[this.stack.length - 1];
+    if (ctx.type === 'array' && ch === ']') {
+      this.stack.pop();
+      this.updates.push(this._cloneRoot());
+      return;
+    }
+    if (ctx.type === 'object' && ch === '}') {
+      if (ctx.state === 'expectColon' || ctx.state === 'expectValue') {
+        throw new Error('Unexpected closing brace');
+      }
+      this.stack.pop();
+      this.updates.push(this._cloneRoot());
+      return;
+    }
+    throw new Error('Mismatched closing bracket');
+  }
+
+  _comma(): void {
+    if (this.stack.length === 0) {
+      throw new Error('Unexpected comma');
+    }
+    const ctx = this.stack[this.stack.length - 1];
+    if (ctx.state !== 'expectCommaOrEnd') {
+      throw new Error('Unexpected comma');
+    }
+    ctx.state = ctx.type === 'object' ? 'expectKey' : 'expectValue';
+  }
+
+  _colon(): void {
+    if (this.stack.length === 0) {
+      throw new Error('Unexpected colon');
+    }
+    const ctx = this.stack[this.stack.length - 1];
+    if (ctx.type !== 'object' || ctx.state !== 'expectColon') {
+      throw new Error('Unexpected colon');
+    }
+    ctx.state = 'expectValue';
+  }
+
+  _cloneRoot(): any {
+    return this.root === undefined ? undefined : JSON.parse(JSON.stringify(this.root));
+  }
+
+  collectUpdates(): any[] {
+    const list = this.updates;
+    this.updates = [];
+    return list;
+  }
+}
+
+export async function* incrementalJsonParser(
+  reader: IncrementalReader
+): AsyncGenerator<any> {
+  const decoder = new TextDecoder();
+  const parser = new IncrementalParser();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      parser.end();
+      const updates = parser.collectUpdates();
+      for (const u of updates) {
+        if (u !== undefined) {
+          yield u;
+        }
+      }
+      break;
+    }
+    parser.feed(decoder.decode(value, { stream: true }));
+    const updates = parser.collectUpdates();
+    for (const u of updates) {
+      if (u !== undefined) {
+        yield u;
+      }
+    }
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './incrementalJsonParser';

--- a/test/incrementalParser.test.ts
+++ b/test/incrementalParser.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { incrementalJsonParser, IncrementalReader } from '../src/index';
+
+function createReader(chunks: string[]): IncrementalReader {
+  const encoder = new TextEncoder();
+  let index = 0;
+  return {
+    async read() {
+      if (index >= chunks.length) return { done: true, value: undefined } as const;
+      return { done: false, value: encoder.encode(chunks[index++]) } as const;
+    },
+  };
+}
+
+describe('incrementalJsonParser', () => {
+  it('parses streaming json and yields snapshots', async () => {
+    const json = '{"a":1,"b":[{"c":2},3]}';
+    const chunks = [json.slice(0,5), json.slice(5,10), json.slice(10)];
+    const reader = createReader(chunks);
+
+    const results: any[] = [];
+    for await (const obj of incrementalJsonParser(reader)) {
+      results.push(obj);
+    }
+
+    expect(results.length).greaterThan(1);
+    expect(results[results.length - 1]).toEqual(JSON.parse(json));
+    // ensure immutability
+    if (results.length >= 2) {
+      expect(results[results.length - 2]).not.toBe(results[results.length - 1]);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "declaration": true,
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "lib": ["esnext"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.ts'),
+      name: 'IncrementalJsonParser',
+      fileName: (format) => `incremental-json-parser.${format}.js`,
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- convert incremental JSON parser to TypeScript
- add Vite build and Vitest test config
- document installation and build steps

## Testing
- ❌ `npm install` (failed: EHOSTUNREACH)
- ❌ `npx vitest run` (failed: EHOSTUNREACH)
